### PR TITLE
refactor: Improve error message for purchase date fix:#1

### DIFF
--- a/.github/workflows/azure-static-web-apps-lively-tree-0917bc303.yml
+++ b/.github/workflows/azure-static-web-apps-lively-tree-0917bc303.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           lfs: false

--- a/src/components/TOBResults.js
+++ b/src/components/TOBResults.js
@@ -39,7 +39,7 @@ const TOBResults = ({
       <>
         <img src={WaitImage} alt="Loading..." className="w-1/2 mx-auto my-8" />
         <p className="m-auto text-center">
-          Please insert a valid purchase price and date.
+          Please insert a valid purchase price and date (not a weekend or bank holiday).
         </p>
       </>
     );

--- a/src/components/TransactionDetails.js
+++ b/src/components/TransactionDetails.js
@@ -1,4 +1,5 @@
-import { formatDate } from "../helper/helpers";
+import {useEffect, useState} from "react";
+import {formatDate, isESPPDateValid} from "../helper/helpers";
 
 const TransactionDetails = ({
   setPurchasePrice,
@@ -6,6 +7,12 @@ const TransactionDetails = ({
   purchaseDate,
   purchasePrice,
 }) => {
+  const [isValidDate, setIsValidDate] = useState(true);
+
+  useEffect(() => {
+    setIsValidDate(isESPPDateValid(purchaseDate));
+  }, [purchaseDate]);
+
   return (
     <>
       <h2 className="text-2xl mb-4">Transaction details</h2>
@@ -34,6 +41,11 @@ const TransactionDetails = ({
           }}
           max={formatDate(new Date())}
         />
+        {!isValidDate && (
+          <p className="text-red-500 text-sm">
+            Purchase date cannot be a weekend or a bank holiday
+          </p>
+        )}
       </div>
     </>
   );

--- a/src/helper/helpers.js
+++ b/src/helper/helpers.js
@@ -26,8 +26,13 @@ function lastESPPDay(currentDate) {
     lastWorkingDate.setDate(lastWorkingDate.getDate() - 1);
   }
 
-  if (lastWorkingDate === new Date("2024-03-29")) {
-    lastWorkingDate = new Date("2024-03-28");
+  const March29 = new Date("2024-03-29");
+  if (
+    lastWorkingDate.getDate() === March29.getDate() &&
+    lastWorkingDate.getMonth() === March29.getMonth() &&
+    lastWorkingDate.getFullYear() === March29.getFullYear()
+  ) {
+    return new Date("2024-03-28");
   }
 
   return lastWorkingDate;
@@ -61,9 +66,18 @@ function roundToTwoDecimals(num) {
   return Math.round(num * 100) / 100;
 }
 
+function isESPPDateValid(date) {
+  return (
+    date.getDay() !== 0 &&
+    date.getDay() !== 6 &&
+    date.getTime() !== new Date("2024-03-29").getTime()
+  );
+}
+
 module.exports = {
   formatDate,
   lastESPPDay,
   getExchangeRate,
   roundToTwoDecimals,
+  isESPPDateValid,
 };


### PR DESCRIPTION
This pull request primarily focuses on improving the validation of purchase dates in the application, specifically excluding weekends and bank holidays. The changes include modifying the error message displayed when an invalid date is entered, adding a new validation function, and updating the existing date validation logic.

User Interface changes:

* [`src/components/TOBResults.js`](diffhunk://#diff-3681990690fcb7587cc064f5786346219d55942727ca30126fb9e7b210ebc466L42-R42): Updated the error message displayed when a user enters an invalid purchase date to specify that weekends and bank holidays are not valid.

Codebase improvements:

* [`src/components/TransactionDetails.js`](diffhunk://#diff-b8695eb892de4fa5f89b583ce6b74feed9474f18505f5fb1883caba8675b99a4L1-R15): Imported `useState` and `useEffect` from React, and the new `isESPPDateValid` function from `helpers.js`. Added new state variable `isValidDate` to keep track of whether the entered purchase date is valid. Added a new effect that updates `isValidDate` whenever `purchaseDate` changes.
* [`src/components/TransactionDetails.js`](diffhunk://#diff-b8695eb892de4fa5f89b583ce6b74feed9474f18505f5fb1883caba8675b99a4R44-R48): Displayed an error message under the date input field if the entered date is not valid.

Functionality enhancements:

* [`src/helper/helpers.js`](diffhunk://#diff-6b94ccfd0a931edff1e6a4cedaa6c90dc6b6cf42640a48de59d5e04aba663485L29-R35): Modified the `lastESPPDay` function to compare the `lastWorkingDate` with March 29, 2024, using the date, month, and year. If they match, the function now returns March 28, 2024.
* [`src/helper/helpers.js`](diffhunk://#diff-6b94ccfd0a931edff1e6a4cedaa6c90dc6b6cf42640a48de59d5e04aba663485R69-R82): Added a new function `isESPPDateValid` that checks if a given date is not a weekend and not March 29, 2024. This function is exported from the module.