### PR TITLE
refactor: Add email intro continuation for Dutch language

### DIFF
--- a/src/helper/translations.js
+++ b/src/helper/translations.js
@@ -19,6 +19,11 @@ const translations = {
     fr: "Veuillez-trouver, ci-joints, le document de déclaration TOB ainsi qu'une copie de la preuve de paiement de cette taxe pour le mois de",
     nl: "Gelieve in bijlage het document van de TOB-aangifte en een kopie van het betalingsbewijs van deze belasting voor de maand",
   },
+  emailIntroContinued: {
+    en: "",
+    fr: "",
+    nl: "te vinden",
+  },
   months: {
     1: {
       en: "January",

--- a/src/steps/Email.js
+++ b/src/steps/Email.js
@@ -21,7 +21,9 @@ const Email = ({ language, purchaseDate, tob }) => {
         {translations.emailIntro[language]}
         {"  "}
         {translations.months[purchaseDate.getMonth() + 1][language]}{" "}
-        {purchaseDate.getFullYear()}.
+        {purchaseDate.getFullYear()}
+        {language === "nl" && " "}
+        {translations.emailIntroContinued[language]}.
         <br />
         {translations.ssn[language]}:{" "}
         <span className="text-red-600">[Your Social Security Number]</span>


### PR DESCRIPTION
This pull request includes changes to enhance the multilingual support in the application. The most important changes involve adding a new translation key and modifying the `Email` component to incorporate the new translation key for the Dutch language.

Closes #3 

Changes to translations:

* [`src/helper/translations.js`](diffhunk://#diff-46f22750e91a9c4592a38b67b46a0cca7908f2ede2e63d2a49ff0c71c53681ccR22-R26): Added a new translation key `emailIntroContinued` to the `translations` object. This key includes an English, French, and Dutch translation. The Dutch translation is "te vinden", while the English and French translations are currently empty.

Changes to components:

* [`src/steps/Email.js`](diffhunk://#diff-b81d2570f7a5e6cfa80bcadd3fe5ebee1c286a920e3b4757998b8539e2064dd7L24-R26): Modified the `Email` component to include the new translation key `emailIntroContinued` in the email text. This change currently only affects the Dutch language version of the email, as the English and French translations for this key are empty.